### PR TITLE
Use the room's scoresheet to load rosters for Lifsheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ If you want to use the Dev Server (required for testing Google Sheets), then do 
 
 # Contribute
 
-Contributions are welcomed.
+Contributions are welcomed. Please verify that `npm lint` and `npm test` succeed without warnings or failures before submitting a pull request.

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -169,6 +169,11 @@ const ExportSettingsDialogBody = observer(
             <Stack tokens={settingsStackTokens}>
                 <TextField
                     label="SheetsUrl"
+                    defaultValue={
+                        sheet.sheetId == undefined || sheet.sheetId.length === 0
+                            ? ""
+                            : `${sheetsPrefix}${sheet.sheetId}`
+                    }
                     required={true}
                     onChange={sheetsUrlChangeHandler}
                     onGetErrorMessage={validateSheetsUrl}
@@ -250,7 +255,6 @@ function onClose(props: IExportDialogProps): void {
 function hideDialog(props: IExportDialogProps): void {
     const uiState: UIState = props.appState.uiState;
     uiState.resetPendingSheet();
-    uiState.sheetsState.clearRoundNumber();
     uiState.sheetsState.clearExportStatus();
 }
 

--- a/src/components/NewGameDialog.tsx
+++ b/src/components/NewGameDialog.tsx
@@ -291,7 +291,7 @@ const FromLifsheetsNewGameBody = observer(
                     <div className={props.classes.loadContainer}>
                         <TextField
                             styles={rostersInputStyles}
-                            label="URL to rosters"
+                            label="URL to room scoresheet"
                             value={pendingNewGame.rostersUrl}
                             onChange={rostersUrlChangeHandler}
                         />
@@ -386,7 +386,15 @@ function onSubmit(props: INewGameDialogProps): void {
     game.loadPacket(pendingNewGame.packet);
 
     // If we've just started a new game, start at the beginning
-    props.appState.uiState.setCycleIndex(0);
+    uiState.setCycleIndex(0);
+
+    // If we're manually entering names, clear the sheetsId field, since we don't have a scoresheet for this game
+    if (pendingNewGame.type === PendingGameType.Manual) {
+        uiState.resetSheetsId();
+    }
+
+    // We always want to reset the round number, since this could be for a different round
+    uiState.sheetsState.clearRoundNumber();
 
     hideDialog(props);
 }

--- a/src/sheets/Sheets.ts
+++ b/src/sheets/Sheets.ts
@@ -399,7 +399,7 @@ export async function loadRosters(appState: AppState, sheetsApi: ISheetsApi = Sh
 
     let values: gapi.client.sheets.ValueRange;
     try {
-        const response: ISheetsGetResponse = await sheetsApi.get(uiState, "Rosters!C2:I49");
+        const response: ISheetsGetResponse = await sheetsApi.get(uiState, "Rosters!A2:L");
         if (!response.success) {
             uiState.sheetsState.setRosterLoadStatus(
                 {
@@ -438,6 +438,16 @@ export async function loadRosters(appState: AppState, sheetsApi: ISheetsApi = Sh
             {
                 isError: true,
                 status: `Not enough teams. Only found ${values.values.length} team(s).`,
+            },
+            LoadingState.Error
+        );
+        return;
+    } else if (values.values[0].length > 2 && values.values[0][0] === "1" && values.values[0][1] === "") {
+        uiState.sheetsState.setRosterLoadStatus(
+            {
+                isError: true,
+                status:
+                    "Roster spreadsheet is from the control sheet instead of the reader's scoresheet. Please paste the URL to your scoresheet.",
             },
             LoadingState.Error
         );

--- a/src/state/SheetState.ts
+++ b/src/state/SheetState.ts
@@ -19,10 +19,10 @@ export class SheetState {
     @ignore
     public rosterLoadState: LoadingState | undefined;
 
-    @ignore
+    // We need to remember sheetId, since we only input it when creating the game
     public sheetId?: string;
 
-    @ignore
+    // We want to remember the round number, so we can keep exporting to the same round
     public roundNumber?: number;
 
     constructor() {

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -141,8 +141,8 @@ export class UIState {
 
     public createPendingSheet(): void {
         this.pendingSheet = {
-            roundNumber: 1,
-            sheetId: "",
+            roundNumber: this.sheetsState.roundNumber ?? 1,
+            sheetId: this.sheetsState.sheetId ?? "",
         };
     }
 

--- a/tests/SheetsTests.ts
+++ b/tests/SheetsTests.ts
@@ -754,6 +754,28 @@ describe("SheetsTests", () => {
                 "Not all teams have players. Check the roster sheet to make sure at least 1 player is on each team."
             );
         });
+        it("Control sheet", async () => {
+            const appState: AppState = createAppStateForRosters();
+
+            const mockSheetsApi: ISheetsApi = createMockApi({
+                get: () =>
+                    Promise.resolve<ISheetsGetResponse>({
+                        success: true,
+                        valueRange: {
+                            values: [
+                                ["1", "", "Alpha", "Alice", "Andrew", "Ana"],
+                                ["2", "", "Beta", "Bob"],
+                            ],
+                        },
+                    }),
+            });
+
+            await verifyLoadRostersError(
+                appState,
+                mockSheetsApi,
+                "Roster spreadsheet is from the control sheet instead of the reader's scoresheet. Please paste the URL to your scoresheet."
+            );
+        });
         it("API failure", async () => {
             const appState: AppState = createAppStateForRosters();
 


### PR DESCRIPTION
- Use the room's scoresheet to load rosters for Lifsheets
    - This means the user only needs to paste the URL once, and we can remember it for the export dialog
    - We auto-fill the URL in the export dialog if we know it
- Remember the round number in the export dialog for the whole game
- Use an unbound range for the rosters (#34)